### PR TITLE
Implement new features:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+### 1.0.0-dev
+
+* Initial release, includes all functionality found in the README.

--- a/test/custom_extension/cases.data
+++ b/test/custom_extension/cases.data
@@ -1,0 +1,4 @@
+>>> this file has a custom extension
+the input
+<<<
+the output

--- a/test/custom_extension/ignored.unit
+++ b/test/custom_extension/ignored.unit
@@ -1,0 +1,4 @@
+>>> this better be ignored
+because the test
+<<<
+is looking for .data files.

--- a/test/custom_extension_test.dart
+++ b/test/custom_extension_test.dart
@@ -1,0 +1,35 @@
+library expected_output.test.custom_extension_test;
+
+import 'dart:mirrors';
+
+import 'package:expected_output/expected_output.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('parses case w/o a description', () {
+    // Locate the "test" directory. Use mirrors so that this works with the test
+    // package, which loads this suite into an isolate.
+    var testDir = p.dirname(currentMirrorSystem()
+        .findLibrary(#expected_output.test.custom_extension_test)
+        .uri
+        .toFilePath());
+    var iterator = dataCases(
+            directory: p.join(testDir, 'custom_extension'), extension: 'data')
+        .iterator;
+    iterator.moveNext();
+    var dataCase = iterator.current;
+
+    expect(dataCase.directory, 'custom_extension');
+    expect(dataCase.file, 'cases');
+    expect(dataCase.description, 'line 2: this file has a custom extension');
+    expect(dataCase.testDescription,
+        'custom_extension cases line 2: ' 'this file has a custom extension');
+    expect(dataCase.input, 'the input\n');
+    expect(dataCase.expectedOutput, 'the output\n');
+    expect(dataCase.skip, false);
+
+    var iteratorIsEmpty = !iterator.moveNext();
+    expect(iteratorIsEmpty, isTrue);
+  });
+}

--- a/test/library_test.dart
+++ b/test/library_test.dart
@@ -1,0 +1,36 @@
+library expected_output.test.recursive_test;
+
+import 'package:expected_output/expected_output.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('finds test cases when passed a library Symbol', () {
+    var iterator = dataCasesUnder(library: #expected_output.test.recursive_test,
+            subdirectory: 'recursive_data', recursive: false)
+        .iterator;
+    iterator.moveNext();
+    var dataCase = iterator.current;
+
+    expect(dataCase.directory, 'recursive_data');
+    expect(dataCase.file, 'foo');
+    expect(dataCase.description, 'line 2: data case in the primary directory');
+
+    var iteratorIsEmpty = !iterator.moveNext();
+    expect(iteratorIsEmpty, isTrue);
+  });
+
+  test('finds test cases when passed a library Symbol, and subdirectories', () {
+    var iterator = dataCasesUnder(library: #expected_output.test.recursive_test,
+            subdirectory: 'recursive_data/deep', recursive: false)
+        .iterator;
+    iterator.moveNext();
+    var dataCase = iterator.current;
+
+    expect(dataCase.directory, 'deep');
+    expect(dataCase.file, 'bar');
+    expect(dataCase.description, 'line 2: a deeper data case');
+
+    var iteratorIsEmpty = !iterator.moveNext();
+    expect(iteratorIsEmpty, isTrue);
+  });
+}

--- a/test/recursive_data/deep/bar.unit
+++ b/test/recursive_data/deep/bar.unit
@@ -1,0 +1,4 @@
+>>> a deeper data case
+with inputs
+<<<
+and outputs

--- a/test/recursive_data/deep/deeper/baz.unit
+++ b/test/recursive_data/deep/deeper/baz.unit
@@ -1,0 +1,4 @@
+>>> deeper test case
+two directories down
+<<<
+from the base folder

--- a/test/recursive_data/foo.unit
+++ b/test/recursive_data/foo.unit
@@ -1,0 +1,4 @@
+>>> data case in the primary directory
+some input
+<<<
+some output

--- a/test/recursive_test.dart
+++ b/test/recursive_test.dart
@@ -1,0 +1,64 @@
+library expected_output.test.recursive_test;
+
+import 'dart:mirrors';
+
+import 'package:expected_output/expected_output.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  test('looks for data cases recursively', () {
+    // Locate the "test" directory. Use mirrors so that this works with the test
+    // package, which loads this suite into an isolate.
+    var testDir = p.dirname(currentMirrorSystem()
+        .findLibrary(#expected_output.test.recursive_test)
+        .uri
+        .toFilePath());
+    var iterator =
+        dataCases(directory: p.join(testDir, 'recursive_data')).iterator;
+    iterator.moveNext();
+    var dataCase = iterator.current;
+
+    expect(dataCase.directory, 'recursive_data/deep');
+    expect(dataCase.file, 'bar');
+    expect(dataCase.description, 'line 2: a deeper data case');
+
+    iterator.moveNext();
+    dataCase = iterator.current;
+
+    expect(dataCase.directory, 'recursive_data/deep/deeper');
+    expect(dataCase.file, 'baz');
+    expect(dataCase.description, 'line 2: deeper test case');
+
+    iterator.moveNext();
+    dataCase = iterator.current;
+
+    expect(dataCase.directory, 'recursive_data');
+    expect(dataCase.file, 'foo');
+    expect(dataCase.description, 'line 2: data case in the primary directory');
+
+    var iteratorIsEmpty = !iterator.moveNext();
+    expect(iteratorIsEmpty, isTrue);
+  });
+
+  test('looks for data cases non-recursively', () {
+    // Locate the "test" directory. Use mirrors so that this works with the test
+    // package, which loads this suite into an isolate.
+    var testDir = p.dirname(currentMirrorSystem()
+        .findLibrary(#expected_output.test.recursive_test)
+        .uri
+        .toFilePath());
+    var iterator = dataCases(
+            directory: p.join(testDir, 'recursive_data'), recursive: false)
+        .iterator;
+    iterator.moveNext();
+    var dataCase = iterator.current;
+
+    expect(dataCase.directory, 'recursive_data');
+    expect(dataCase.file, 'foo');
+    expect(dataCase.description, 'line 2: data case in the primary directory');
+
+    var iteratorIsEmpty = !iterator.moveNext();
+    expect(iteratorIsEmpty, isTrue);
+  });
+}

--- a/test/simple_data/cases.unit
+++ b/test/simple_data/cases.unit
@@ -20,3 +20,9 @@ five
 <<<
 output
 five
+>>> skip: don't run this test
+input
+six
+<<<
+output
+six

--- a/test/simple_test.dart
+++ b/test/simple_test.dart
@@ -27,12 +27,13 @@ void main() {
   });
 
   test('parses case w/o a description', () {
-    expect(dataCase.directory, endsWith('simple_data'));
+    expect(dataCase.directory, 'simple_data');
     expect(dataCase.file, 'cases');
     expect(dataCase.description, 'line 2');
     expect(dataCase.testDescription, 'simple_data cases line 2');
     expect(dataCase.input, 'input 1\n');
     expect(dataCase.expectedOutput, 'output 1\n');
+    expect(dataCase.skip, false);
   });
 
   test('parses case w/ whitespace after >>>', () {
@@ -55,8 +56,13 @@ void main() {
     expect(dataCase.expectedOutput, 'output\nfive\n');
   });
 
+  test('parses case w/ skip description', () {
+    expect(dataCase.description, 'line 24: skip: don\'t run this test');
+    expect(dataCase.skip, true);
+  });
+
   test('parses case w/o a description', () {
-    expect(dataCase.directory, endsWith('simple_data'));
+    expect(dataCase.directory, 'simple_data');
     expect(dataCase.file, 'cases2');
     expect(dataCase.description, 'line 2: a second unit file');
     expect(dataCase.testDescription,


### PR DESCRIPTION
Fixes #2. Fixes #3.

* `dataCases` and `dataCasesUnder` now accept `extension:` and
  `recursive:` named arguments.
* `dataCasesUnder` now accepts a `subdirectory:` named argument.
* The data case parser now marks cases that start with "skip:" as
  skipped.