### PR TITLE
Add test helper APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.1.0
+
+* Add test helpers `testDataCases` and `testDataCasesUnder`.
+
 ### 1.0.0
 
 * Initial release, includes all functionality found in the README.

--- a/README.md
+++ b/README.md
@@ -80,12 +80,38 @@ The `expected_output` API is small. Here's the gist:
 * `dataCases(directory: 'some/directory')` \
   Iterate over all of the `.unit` files in `'some/directory'`, yielding
   DataCases with input/output information.
+
 * `dataCasesUnder(library: #your.test.library)` \
   Iterate over all of the `.unit` files in the directory where
   `#your.test.library` Dart library is declared. This is just a convenience
   method so that you don't need to import mirrors in your test.
+
 * `dataCasesInFile(path: 'path/to/your/data.unit')` \
   Iterate over all of the DataCases found in `'path/to/your/data.unit'`.
+
+* ```dart
+  testDataCases(
+      directory: 'some/directory',
+      testBody: (DataCase dataCase) {
+        expect(something(dataCase.input), dataCase.expected_output);
+      });
+  ```
+
+  Iterate over all of the DataCases found in `'some/directory'`, declaring a
+  [test package] test case for each, using `testBody` as the body of the test
+  case.
+
+* ```dart
+  testDataCasesUnder(
+      library: #your.test.library,
+      testBody: (DataCase dataCase) {
+        expect(something(dataCase.input), dataCase.expected_output);
+      });
+  ```
+
+  Iterate over all of the DataCases found in the directory where
+  `#your.test.library` Dart library is declared, declaring a [test package] test
+  case for each, using `testBody` as the body of the test case.
 
 ## When to use
 
@@ -105,3 +131,5 @@ probably much easier to write input and expected output in simple text blocks
 in simple text files. Examples would include a Markdown parser that needs to
 parse indented list continuations or indented code blocks, and text formatters
 that need to test specific indentation in the output.
+
+[test package]: https://pub.dartlang.org/packages/test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: expected_output
-version: 1.0.0
+version: 1.1.0
 description: Easily write and test  multiline input and expected output
 author: Dart Team <misc@dartlang.org>
 homepage: http://pub.dartlang.org/packages/expected_output

--- a/test/test_helper_test.dart
+++ b/test/test_helper_test.dart
@@ -1,0 +1,45 @@
+library expected_output.test.recursive_test;
+
+import 'dart:mirrors';
+
+import 'package:expected_output/expected_output.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('testDataCasesUnder', () {
+    var testDataCaseCount = 0;
+
+    testDataCasesUnder(
+        library: #expected_output.test.recursive_test,
+        subdirectory: 'recursive_data',
+        testBody: (DataCase dataCase) {
+          expect(dataCase.description, isNotEmpty);
+          testDataCaseCount++;
+        });
+
+    // TODO(srawlins): This is brittle; it super depends on the test cases
+    // above being run _before_ this test case. Not good. Find a way to
+    // test the test framework from within the test framework.
+    test('declares all recursive tests', () {
+      expect(testDataCaseCount, 3);
+    });
+  });
+
+  group('testDataCasesUnder', () {
+    var testDataCaseCount = 0;
+
+    testDataCasesUnder(
+        library: #expected_output.test.recursive_test,
+        subdirectory: 'recursive_data',
+        recursive: false,
+        testBody: (DataCase dataCase) {
+          expect(dataCase.description, isNotEmpty);
+          testDataCaseCount++;
+        });
+
+    test('declares all immediate tests', () {
+      expect(testDataCaseCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
The README changes have a pretty good description of these features.

This feature is really the endgame of why I wanted this package :stuck_out_tongue_closed_eyes: : I want a helper function that iterates over inputs and expected outputs, and defines a test case (with a description, and a value for `skip:`) for each pair.