### PR TITLE
Migrate to Dart 2.12 with null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0
+
+* Migrate to null-safety
+* Set min SDK version to >=2.12.0
+
 ## 1.2.2
 
 * Improved package description and added an example.

--- a/lib/expected_output.dart
+++ b/lib/expected_output.dart
@@ -9,7 +9,8 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 /// Parse and yield data cases (each a [DataCase]) from [path].
-Iterable<DataCase> dataCasesInFile({String path, String baseDir}) sync* {
+Iterable<DataCase> dataCasesInFile(
+    {required String path, String? baseDir}) sync* {
   var file = p.basename(path).replaceFirst(RegExp(r'\..+$'), '');
   baseDir ??= p.relative(p.dirname(path), from: p.dirname(p.dirname(path)));
 
@@ -61,7 +62,7 @@ Iterable<DataCase> dataCasesInFile({String path, String baseDir}) sync* {
 /// cases are read from files located immediately in [directory], or
 /// recursively, according to [recursive].
 Iterable<DataCase> dataCases({
-  String directory,
+  required String directory,
   String extension = 'unit',
   bool recursive = true,
 }) {
@@ -113,7 +114,7 @@ Iterable<DataCase> dataCases({
 /// }
 /// ```
 Iterable<DataCase> dataCasesUnder({
-  Symbol library,
+  required Symbol library,
   String subdirectory = '',
   String extension = 'unit',
   bool recursive = true,
@@ -135,10 +136,10 @@ Iterable<DataCase> dataCasesUnder({
 ///
 /// A test will be skipped if it's description starts with "skip:".
 void testDataCases(
-    {String directory,
+    {required String directory,
     String extension = 'unit',
     bool recursive = true,
-    void Function(DataCase dataCase) testBody}) {
+    required void Function(DataCase dataCase) testBody}) {
   for (var dataCase in dataCases(
       directory: directory, extension: extension, recursive: recursive)) {
     test(dataCase.description, () => testBody(dataCase), skip: dataCase.skip);
@@ -174,11 +175,11 @@ void testDataCases(
 /// }
 /// ```
 void testDataCasesUnder(
-    {Symbol library,
+    {required Symbol library,
     String subdirectory = '',
     String extension = 'unit',
     bool recursive = true,
-    void Function(DataCase dataCase) testBody}) {
+    required void Function(DataCase dataCase) testBody}) {
   for (var dataCase in dataCasesUnder(
       library: library,
       subdirectory: subdirectory,
@@ -202,14 +203,14 @@ class DataCase {
   final String expectedOutput;
 
   DataCase({
-    this.directory,
-    this.file,
+    required this.directory,
+    required this.file,
     // ignore: non_constant_identifier_names
-    this.front_matter,
-    this.description,
-    this.skip,
-    this.input,
-    this.expectedOutput,
+    required this.front_matter,
+    required this.description,
+    required this.skip,
+    required this.input,
+    required this.expectedOutput,
   });
 
   /// A good standard description for `test()`, derived from the data directory,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: expected_output
-version: 1.2.2
+version: 2.0.0
 description: >-
   Easily write and test multiline input and expected output, and avoid test case
   data clutter in your test logic.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/expected_output
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   path: ^1.4.1

--- a/test/front_matter_test.dart
+++ b/test/front_matter_test.dart
@@ -11,9 +11,9 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  Iterator iterator;
-  var dataCase;
-  var iteratorIsEmpty;
+  late Iterator<DataCase> iterator;
+  late DataCase dataCase;
+  late bool iteratorIsEmpty;
 
   setUpAll(() {
     // Locate the "test" directory. Use mirrors so that this works with the test
@@ -27,7 +27,9 @@ void main() {
 
   setUp(() {
     iteratorIsEmpty = !iterator.moveNext();
-    dataCase = iterator.current;
+    if (!iteratorIsEmpty) {
+      dataCase = iterator.current;
+    }
   });
 
   test('parses front matter as a string', () {

--- a/test/simple_test.dart
+++ b/test/simple_test.dart
@@ -11,9 +11,9 @@ import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
-  Iterator iterator;
-  var dataCase;
-  var iteratorIsEmpty;
+  late Iterator<DataCase> iterator;
+  late DataCase dataCase;
+  late bool iteratorIsEmpty;
 
   setUpAll(() {
     // Locate the "test" directory. Use mirrors so that this works with the test
@@ -27,7 +27,9 @@ void main() {
 
   setUp(() {
     iteratorIsEmpty = !iterator.moveNext();
-    dataCase = iterator.current;
+    if (!iteratorIsEmpty) {
+      dataCase = iterator.current;
+    }
   });
 
   test('parses case w/o a description', () {


### PR DESCRIPTION
Set minimum SDK to >= 2.12.0 and applied type changes to support null-safety.
The version was updated to 2.0.0 as this might have breaking changes.